### PR TITLE
Corrected reference to AutoExpMaxExpMS in zwoasi_demo.py

### DIFF
--- a/zwoasi/examples/zwoasi_demo.py
+++ b/zwoasi/examples/zwoasi_demo.py
@@ -152,7 +152,7 @@ if 'Exposure' in controls and controls['Exposure']['IsAutoSupported']:
                                  auto=True)
 
     # Keep max gain to the default but allow exposure to be increased to its maximum value if necessary
-    camera.set_control_value(controls['AutoExpMaxExp']['ControlType'], controls['AutoExpMaxExp']['MaxValue'])
+    camera.set_control_value(controls['AutoExpMaxExpMS']['ControlType'], controls['AutoExpMaxExpMS']['MaxValue'])
 
     print('Waiting for auto-exposure to compute correct settings ...')
     sleep_interval = 0.100


### PR DESCRIPTION
At least with my ASI120MM-S the control value is AutoExpMaxExpMS, not AutoExpMaxExp.

```
asgaut@skycam:~/python-zwoasi/zwoasi/examples $ python3 zwoasi_demo.py libASICamera2.so
Found one camera: ZWO ASI120MM-S
Camera controls:
    AutoExpMaxExpMS:
        ControlType: 11
        DefaultValue: 100
        Description: 'Auto exposure maximum exposure value(unit ms)'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 60000
        MinValue: 1
        Name: 'AutoExpMaxExpMS'
    AutoExpMaxGain:
        ControlType: 10
        DefaultValue: 50
        Description: 'Auto exposure maximum gain value'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 100
        MinValue: 0
        Name: 'AutoExpMaxGain'
    AutoExpTargetBrightness:
        ControlType: 12
        DefaultValue: 100
        Description: 'Auto exposure maximum brightness value'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 160
        MinValue: 50
        Name: 'AutoExpTargetBrightness'
    BandWidth:
        ControlType: 6
        DefaultValue: 50
        Description: 'The total data transfer rate percentage'
        IsAutoSupported: True
        IsWritable: True
        MaxValue: 100
        MinValue: 40
        Name: 'BandWidth'
    Brightness:
        ControlType: 5
        DefaultValue: 0
        Description: 'Brightness(offset)'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 20
        MinValue: 0
        Name: 'Brightness'
    Exposure:
        ControlType: 1
        DefaultValue: 14000
        Description: 'Exposure Time(us)'
        IsAutoSupported: True
        IsWritable: True
        MaxValue: 2000000000
        MinValue: 64
        Name: 'Exposure'
    Flip:
        ControlType: 9
        DefaultValue: 0
        Description: 'Flip: 0->None 1->Horiz 2->Vert 3->Both'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 3
        MinValue: 0
        Name: 'Flip'
    Gain:
        ControlType: 0
        DefaultValue: 50
        Description: 'Gain'
        IsAutoSupported: True
        IsWritable: True
        MaxValue: 100
        MinValue: 0
        Name: 'Gain'
    Gamma:
        ControlType: 2
        DefaultValue: 50
        Description: 'Gamma'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 100
        MinValue: 1
        Name: 'Gamma'
    HighSpeedMode:
        ControlType: 14
        DefaultValue: 0
        Description: 'Is high speed mode:0->No 1->Yes'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 1
        MinValue: 0
        Name: 'HighSpeedMode'
    OverCLK:
        ControlType: 7
        DefaultValue: 0
        Description: 'Over clocking percentage'
        IsAutoSupported: False
        IsWritable: True
        MaxValue: 30
        MinValue: 0
        Name: 'OverCLK'
    Temperature:
        ControlType: 8
        DefaultValue: 20
        Description: 'Sensor temperature(degrees Celsius)'
        IsAutoSupported: False
        IsWritable: False
        MaxValue: 1000
        MinValue: -500
        Name: 'Temperature'
Enabling stills mode
Capturing a single 8-bit mono image
Saved to image_mono.jpg
Camera settings saved to image_mono.jpg.txt
Capturing a single 16-bit mono image
Saved to image_mono16.tiff
Camera settings saved to image_mono16.tiff.txt
Color image not available with this camera
Enabling video mode
Enabling auto-exposure mode
Enabling automatic gain setting
Waiting for auto-exposure to compute correct settings ...
   Gain 50  Exposure: 14000.000000 Dropped frames: 0
   Gain 50  Exposure: 31081.000000 Dropped frames: 1
   Gain 50  Exposure: 31081.000000 Dropped frames: 2
   Gain 50  Exposure: 31081.000000 Dropped frames: 3
   Gain 50  Exposure: 31081.000000 Dropped frames: 4
   Gain 50  Exposure: 31081.000000 Dropped frames: 5
   Gain 50  Exposure: 31081.000000 Dropped frames: 6
Capturing a single 8-bit mono frame
Saved to image_video_mono.jpg
Camera settings saved to image_video_mono.jpg.txt
```