### PR TITLE
ASI_OFFSET added, replaces ASI_BRIGHTNESS in recent ASI SDK versions

### DIFF
--- a/zwoasi/__init__.py
+++ b/zwoasi/__init__.py
@@ -16,7 +16,7 @@ import traceback
 
 
 __author__ = 'Steve Marple'
-__version__ = '0.0.22'
+__version__ = '0.0.22.1'
 __license__ = 'MIT'
 
 
@@ -870,6 +870,7 @@ ASI_GAMMA = 2
 ASI_WB_R = 3
 ASI_WB_B = 4
 ASI_BRIGHTNESS = 5
+ASI_OFFSET = 5
 ASI_BANDWIDTHOVERLOAD = 6
 ASI_OVERCLOCK = 7
 ASI_TEMPERATURE = 8  # return 10*temperature


### PR DESCRIPTION
In recent versions of the ASI library (e.g. 1.14.075), the ASI_CONTROL_TYPE ASI_OFFSET replaces ASI_BRIGHTNESS.

